### PR TITLE
Avattathil license input

### DIFF
--- a/ddc_on_aws.json
+++ b/ddc_on_aws.json
@@ -337,7 +337,8 @@
     },
     "Resources": {
       "DDCBucket" : {
-      "Type" : "AWS::S3::Bucket"
+      "Type" : "AWS::S3::Bucket",
+	  "DeletionPolicy" : "Retain"
     },
         "vpc": {
             "Type": "AWS::EC2::VPC",


### PR DESCRIPTION
Added checks so either s3 link or direct json input can be used in license field. (S3 option not advertised to users)
Added S3 Delete Policy (Allow cert backup to be retained when cfn stack delete is requested)
Added QS ID to description. Please leave this in. It will help us track usage of the template
