### PR TITLE
Add Jumphost IP to outputs

### DIFF
--- a/ddc_on_aws.json
+++ b/ddc_on_aws.json
@@ -2176,6 +2176,12 @@
                 "Fn::Join": [ "", ["ssh -i <your-private-key.pem> ubuntu@", {"Fn::GetAtt" : [ "Jumphost", "PublicIp"] } ] ]
             }
         },
+        "JumphostIP":{
+            "Description": "Jumphost IP for an A record.",
+            "Value": {
+                "FN::GetAtt": [ "Jumphost", "PublicIp" ]
+            }
+        },
         "S3Bucket":{
             "Description": "S3 Bucket Name for DDC. S3 Bucket was used to backup Root CA. You may also use this bucket to store DTR images.",
             "Value" :


### PR DESCRIPTION
This makes it easier to consume jump host IP for scripting/automation
purposes.